### PR TITLE
fix: Replace btoa() with Node.js compatible Buffer.from().toString('base64')

### DIFF
--- a/src/tools/repositories.test.ts
+++ b/src/tools/repositories.test.ts
@@ -246,7 +246,7 @@ describe('Repository Tools', () => {
         repo: 'test-repo',
         path: 'existing-file.txt',
         message: 'Update file',
-        content: btoa('Updated content'),
+        content: Buffer.from('Updated content').toString('base64'),
         sha: 'existing-sha',
         branch: undefined,
       });

--- a/src/tools/repositories.test.ts
+++ b/src/tools/repositories.test.ts
@@ -246,7 +246,9 @@ describe('Repository Tools', () => {
         repo: 'test-repo',
         path: 'existing-file.txt',
         message: 'Update file',
-        content: Buffer.from('Updated content').toString('base64'),
+        content: (typeof Buffer !== 'undefined' ? Buffer : require('buffer').Buffer)
+          .from('Updated content')
+          .toString('base64'),
         sha: 'existing-sha',
         branch: undefined,
       });


### PR DESCRIPTION
### **User description**
Fixes critical Node.js compatibility issue by replacing browser-only btoa() function with Node.js native Buffer approach.

## Changes
- Replace btoa() usage in src/tools/repositories.test.ts line 249
- Ensure compatibility across all Node.js environments

Fixes #31

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace browser-only `btoa()` with Node.js compatible `Buffer.from().toString('base64')`

- Fix Node.js compatibility issue in test file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["btoa() function"] -- "replace with" --> B["Buffer.from().toString('base64')"]
  B --> C["Node.js compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.test.ts</strong><dd><code>Replace btoa with Buffer for Node.js compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/repositories.test.ts

<ul><li>Replace <code>btoa('Updated content')</code> with <code>Buffer.from('Updated </code><br><code>content').toString('base64')</code><br> <li> Fix Node.js compatibility in test assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/github-mcp/pull/65/files#diff-1955ec31074a6e6aadbdb6219db25ee12e32aa30ffdde4b00a5b2d0388ba5849">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

