### PR TITLE
🚨 SECURITY: Fix critical untrusted checkout vulnerability in dependency-review workflow

### DIFF
--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, edited]
   pull_request_target:
     types: [opened, edited, synchronize, ready_for_review]
+  pull_request:
+    types: [opened, synchronize]
   issue_comment:
     types: [created]
 
@@ -189,14 +191,13 @@ jobs:
 
   dependency-review:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
+    # SECURITY FIX: Changed from pull_request_target to pull_request
+    # to prevent untrusted code execution in privileged context
+    if: github.event_name == 'pull_request'
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
+      # The dependency-review-action handles checkout safely
+      # No explicit checkout needed when using pull_request trigger
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -194,7 +194,10 @@ jobs:
     # SECURITY FIX: Changed from pull_request_target to pull_request
     # to prevent untrusted code execution in privileged context
     if: github.event_name == 'pull_request'
-    
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
       # The dependency-review-action handles checkout safely
       # No explicit checkout needed when using pull_request trigger


### PR DESCRIPTION
### **User description**
## 🔒 Security Fix: Critical Vulnerability in GitHub Actions Workflow

### Problem
CodeQL Security Alert #18 identified a **critical security vulnerability** (CWE-829) in our PR management workflow. The vulnerability allows untrusted code execution in a privileged context, potentially compromising repository security.

### Attack Vector
The `dependency-review` job was using:
1. `pull_request_target` trigger (runs with full repository permissions)
2. Explicit checkout of untrusted PR code with `ref: ${{ github.event.pull_request.head.sha }}`

This combination allows malicious actors to:
- Execute arbitrary code with repository secrets access
- Push malicious commits to protected branches
- Steal sensitive information from the repository

### Solution
This PR fixes the vulnerability by:
- ✅ Changing the trigger from `pull_request_target` to `pull_request` for the dependency-review job
- ✅ Removing the explicit checkout of untrusted code
- ✅ Letting dependency-review-action@v4 handle checkout safely

### Security Impact
- **Before**: Untrusted PR code runs with full repository permissions
- **After**: Untrusted PR code runs in an isolated, unprivileged environment

### Testing
The dependency-review-action@v4 works correctly with the `pull_request` trigger and handles the repository checkout internally in a safe manner.

### References
- [GitHub Security Lab: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- [CodeQL Alert #18](https://github.com/quanticsoul4772/github-mcp/security/code-scanning/18)

### Checklist
- [x] Security vulnerability identified and understood
- [x] Fix implemented following GitHub security best practices
- [x] No functionality lost (dependency review still works)
- [x] Workflow maintains existing permissions model

**This is a critical security fix that should be merged as soon as possible.**


___

### **PR Type**
Bug fix


___

### **Description**
- Fix critical security vulnerability in GitHub Actions workflow

- Change dependency-review trigger from `pull_request_target` to `pull_request`

- Remove explicit checkout of untrusted PR code

- Prevent untrusted code execution in privileged context


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pull_request_target trigger"] --> B["Security Vulnerability"]
  C["pull_request trigger"] --> D["Safe Execution"]
  E["Explicit checkout removal"] --> D
  B --> F["Untrusted code with privileges"]
  D --> G["Isolated unprivileged environment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-management.yml</strong><dd><code>Security fix for dependency-review workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-management.yml

<ul><li>Add <code>pull_request</code> trigger for dependency-review job<br> <li> Change job condition from <code>pull_request_target</code> to <code>pull_request</code><br> <li> Remove explicit checkout step with untrusted PR head SHA<br> <li> Add security fix comments explaining the changes</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/github-mcp/pull/122/files#diff-7f6b8d3a8e74d38d553992c35862eecaa9e72d73d6fe58469846333b957ab8e9">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

